### PR TITLE
Implement SortableJS note reordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The Flask Notes Web Application is a feature-rich web platform designed to provi
 
 * Users can create, edit, and delete notes.
 * Notes can be organized into categories or tags for easy navigation.
+* Notes can be reordered via drag-and-drop using SortableJS.
 * Rich text editing capabilities enable users to format their notes.
 
 3. Search and Filtering:

--- a/website/models.py
+++ b/website/models.py
@@ -6,6 +6,7 @@ class Note(db.Model):
     id = db.Column(db.Integer,primary_key=True)
     data = db.Column(db.String(10000))
     date = db.Column(db.DateTime(timezone=True),default=func.now())
+    position = db.Column(db.Integer, default=0)
     user_id = db.Column(db.Integer,db.ForeignKey('user.id'))
 
 

--- a/website/static/index.js
+++ b/website/static/index.js
@@ -1,8 +1,25 @@
 function deleteNote(noteId) {
-    fetch("/delete-note", {
-      method: "POST",
-      body: JSON.stringify({ noteId: noteId }),
-    }).then((_res) => {
-      window.location.href = "/";
+  fetch("/delete-note", {
+    method: "POST",
+    body: JSON.stringify({ noteId: noteId }),
+  }).then((_res) => {
+    window.location.href = "/";
+  });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const notesList = document.getElementById("notes");
+  if (notesList) {
+    new Sortable(notesList, {
+      animation: 150,
+      onEnd: () => {
+        const order = Array.from(notesList.children).map((li) => li.dataset.id);
+        fetch("/reorder-notes", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ order: order }),
+        });
+      },
     });
   }
+});

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -69,6 +69,7 @@
 
 
 
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
     <script type="text/javascript" src="{{url_for('static',filename='index.js')}}"></script>
 
     <script

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -4,8 +4,8 @@
 {% block content%}
 <h1 align="center">Notes</h1>
 <ul class="list-group list-group-flush" id="notes">
-  {% for note in user.notes %}
-  <li class="list-group-item">
+  {% for note in notes %}
+  <li class="list-group-item" data-id="{{note.id}}">
     {{ note.data }}
     <button type="button" class="close" onClick="deleteNote({{note.id}})">
       <span aria-hidden="true">&times;</span>

--- a/website/views.py
+++ b/website/views.py
@@ -16,15 +16,19 @@ def home():
         if len(note)<1:
             flash('Note is too short',category='error')
         else:
-            new_note = Note(data=note,user_id=current_user.id)
+            # determine next position for the user's notes
+            max_pos = db.session.query(db.func.max(Note.position)).filter_by(user_id=current_user.id).scalar()
+            next_pos = (max_pos or 0) + 1
+            new_note = Note(data=note,user_id=current_user.id, position=next_pos)
             db.session.add(new_note)
             db.session.commit()
             flash('Note added',category='success')
 
-    return render_template("home.html",user=current_user)
+    notes = Note.query.filter_by(user_id=current_user.id).order_by(Note.position).all()
+    return render_template("home.html",user=current_user, notes=notes)
 
 @views.route('/delete-note', methods=['POST'])
-def delete_note():  
+def delete_note():
     note = json.loads(request.data) # this function expects a JSON from the INDEX.js file 
     noteId = note['noteId']
     note = Note.query.get(noteId)
@@ -34,4 +38,17 @@ def delete_note():
             db.session.commit()
 
     return jsonify({})
+
+
+@views.route('/reorder-notes', methods=['POST'])
+@login_required
+def reorder_notes():
+    data = request.get_json()
+    order = data.get('order', []) if data else []
+    for position, note_id in enumerate(order):
+        note = Note.query.get(int(note_id))
+        if note and note.user_id == current_user.id:
+            note.position = position + 1
+    db.session.commit()
+    return jsonify({'success': True})
 


### PR DESCRIPTION
## Summary
- allow drag-and-drop ordering of notes
- persist order through `/reorder-notes` API
- load SortableJS from CDN and wire up client logic
- track note position in the database
- document note reordering in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a3c397e08328b9d334dff296cb54