### PR TITLE
Add color picker for notes

### DIFF
--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -5,7 +5,7 @@
 <h1 align="center">Notes</h1>
 <ul class="list-group list-group-flush" id="notes">
   {% for note in notes %}
-  <li class="list-group-item" data-id="{{note.id}}">
+  <li class="list-group-item" data-id="{{note.id}}" style="background-color: {{ note.color }};">
     {{ note.data }}
     <button type="button" class="close" onClick="deleteNote({{note.id}})">
       <span aria-hidden="true">&times;</span>
@@ -15,6 +15,14 @@
 </ul>
 <form method="POST">
     <textarea name="note" id="note" class="form-control"></textarea>
+    <br />
+    <input
+      type="color"
+      name="color"
+      id="color"
+      value="#ffff00"
+      class="form-control form-control-color"
+    />
     <br />
     <div class="center">
         <button type="submit" class="btn btn-primary">Add Note</button>

--- a/website/views.py
+++ b/website/views.py
@@ -13,13 +13,14 @@ views = Blueprint('views',__name__)
 def home():
     if request.method == 'POST':
         note = request.form.get('note')
+        color = request.form.get('color', '#ffff00')
         if len(note)<1:
             flash('Note is too short',category='error')
         else:
             # determine next position for the user's notes
             max_pos = db.session.query(db.func.max(Note.position)).filter_by(user_id=current_user.id).scalar()
             next_pos = (max_pos or 0) + 1
-            new_note = Note(data=note,user_id=current_user.id, position=next_pos)
+            new_note = Note(data=note,user_id=current_user.id, position=next_pos, color=color)
             db.session.add(new_note)
             db.session.commit()
             flash('Note added',category='success')


### PR DESCRIPTION
## Summary
- let users pick a note color when adding a new note
- show the chosen color behind each note

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855ac715000832885e6be4143c66183