### PR TITLE
Add Markdown rendering for notes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ flask
 Flask-SQLAlchemy
 flask-login
 gunicorn==20.1.0
+markdown
+bleach

--- a/website/models.py
+++ b/website/models.py
@@ -1,12 +1,39 @@
-from . import db 
+from . import db
 from flask_login import UserMixin
 from sqlalchemy.sql import func
+import markdown
+import bleach
+
+
+ALLOWED_TAGS = bleach.sanitizer.ALLOWED_TAGS + [
+    "p",
+    "pre",
+    "code",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+]
+ALLOWED_ATTRIBUTES = {**bleach.sanitizer.ALLOWED_ATTRIBUTES, "img": ["src", "alt"]}
 
 class Note(db.Model):
     id = db.Column(db.Integer,primary_key=True)
     data = db.Column(db.String(10000))
     date = db.Column(db.DateTime(timezone=True),default=func.now())
     user_id = db.Column(db.Integer,db.ForeignKey('user.id'))
+
+    def to_html(self) -> str:
+        """Return sanitized HTML representation of the note's Markdown."""
+        raw_html = markdown.markdown(self.data or "")
+        clean_html = bleach.clean(
+            raw_html,
+            tags=ALLOWED_TAGS,
+            attributes=ALLOWED_ATTRIBUTES,
+            strip=True,
+        )
+        return clean_html
 
 
 class User(db.Model, UserMixin):

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -6,7 +6,7 @@
 <ul class="list-group list-group-flush" id="notes">
   {% for note in user.notes %}
   <li class="list-group-item">
-    {{ note.data }}
+    {{ note.to_html() | safe }}
     <button type="button" class="close" onClick="deleteNote({{note.id}})">
       <span aria-hidden="true">&times;</span>
     </button>


### PR DESCRIPTION
## Summary
- include markdown and bleach packages
- sanitize Markdown notes with bleach
- render sanitized HTML in the notes list

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685595c666188328bd0708d51c071883