### PR TITLE
Add Markdown support with HTML sanitization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ flask
 Flask-SQLAlchemy
 flask-login
 gunicorn==20.1.0
+markdown
+bleach

--- a/website/models.py
+++ b/website/models.py
@@ -2,6 +2,8 @@ from . import db
 from flask_login import UserMixin
 from sqlalchemy.sql import func
 from enum import Enum
+from markdown import markdown
+import bleach
 
 
 class Color(Enum):
@@ -26,6 +28,19 @@ class Note(db.Model):
     color = db.Column(db.String(20), default=Color.YELLOW.value)
     position_class = db.Column(db.String(20), default=Position.LEFT.value)
     user_id = db.Column(db.Integer,db.ForeignKey('user.id'))
+
+    ALLOWED_TAGS = bleach.sanitizer.ALLOWED_TAGS + [
+        "p",
+        "pre",
+        "span",
+    ]
+    ALLOWED_ATTRIBUTES = {"span": ["class"], "a": ["href", "title"]}
+
+    @property
+    def html(self) -> str:
+        """Return sanitized HTML representation of the note."""
+        raw_html = markdown(self.data or "", output_format="html")
+        return bleach.clean(raw_html, tags=self.ALLOWED_TAGS, attributes=self.ALLOWED_ATTRIBUTES)
 
 
 class User(db.Model, UserMixin):

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -6,7 +6,7 @@
 <ul class="list-group list-group-flush" id="notes">
   {% for note in notes %}
   <li class="list-group-item" data-id="{{note.id}}" style="background-color: {{ note.color }};">
-    {{ note.data }}
+    <div class="note-body">{{ note.html|safe }}</div>
     <button type="button" class="close" onClick="deleteNote({{note.id}})">
       <span aria-hidden="true">&times;</span>
     </button>


### PR DESCRIPTION
## Summary
- support Markdown rendering with Bleach sanitization
- expose sanitized HTML via `Note.html` property
- render sanitized HTML on home page
- document dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ae3e37dc83289f796742a19cc165