### PR TITLE
Add category support for notes

### DIFF
--- a/website/__init__.py
+++ b/website/__init__.py
@@ -18,7 +18,7 @@ def create_app():
     app.register_blueprint(views,url_prefix='/')
     app.register_blueprint(auth,url_prefix='/')
 
-    from .models import User , Note
+    from .models import User, Note, Category
     
     create_database(app)
 

--- a/website/models.py
+++ b/website/models.py
@@ -1,12 +1,20 @@
-from . import db 
+from . import db
 from flask_login import UserMixin
 from sqlalchemy.sql import func
+
+
+class Category(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(150))
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    notes = db.relationship('Note', backref='category', lazy=True)
 
 class Note(db.Model):
     id = db.Column(db.Integer,primary_key=True)
     data = db.Column(db.String(10000))
     date = db.Column(db.DateTime(timezone=True),default=func.now())
     user_id = db.Column(db.Integer,db.ForeignKey('user.id'))
+    category_id = db.Column(db.Integer, db.ForeignKey('category.id'))
 
 
 class User(db.Model, UserMixin):
@@ -15,4 +23,5 @@ class User(db.Model, UserMixin):
     password = db.Column(db.String(150))
     firstName = db.Column(db.String(150))
     notes = db.relationship('Note')
+    categories = db.relationship('Category')
 

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -3,18 +3,38 @@
 
 {% block content%}
 <h1 align="center">Notes</h1>
+<div class="mb-3">
+  Categories:
+  <a href="/">All</a>
+  {% for cat in categories %}
+    | <a href="/category/{{cat.id}}">{{cat.name}}</a>
+  {% endfor %}
+</div>
 <ul class="list-group list-group-flush" id="notes">
-  {% for note in user.notes %}
+  {% for note in notes %}
   <li class="list-group-item">
-    {{ note.data }}
+    {% if note.category %}[{{ note.category.name }}] {% endif %}{{ note.data }}
     <button type="button" class="close" onClick="deleteNote({{note.id}})">
       <span aria-hidden="true">&times;</span>
     </button>
   </li>
   {% endfor %}
 </ul>
-<form method="POST">
+<form method="POST" class="mt-3">
     <textarea name="note" id="note" class="form-control"></textarea>
+    <div class="form-row mt-2">
+      <div class="col">
+        <select class="form-control" name="category_select">
+          <option value="" selected>Select category</option>
+          {% for cat in categories %}
+            <option value="{{cat.id}}">{{cat.name}}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="col">
+        <input type="text" name="category_new" class="form-control" placeholder="New category" />
+      </div>
+    </div>
     <br />
     <div class="center">
         <button type="submit" class="btn btn-primary">Add Note</button>

--- a/website/views.py
+++ b/website/views.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, render_template, request, flash, jsonify
 from flask_login import login_required,current_user
-from .models import Note
+from .models import Note, Category
 from . import db
 import json
 
@@ -13,15 +13,36 @@ views = Blueprint('views',__name__)
 def home():
     if request.method == 'POST':
         note = request.form.get('note')
+        category_id = request.form.get('category_select')
+        new_category_name = request.form.get('category_new')
+        category = None
+        if new_category_name:
+            category = Category(name=new_category_name, user_id=current_user.id)
+            db.session.add(category)
+            db.session.commit()
+        elif category_id:
+            category = Category.query.filter_by(id=category_id, user_id=current_user.id).first()
+
         if len(note)<1:
             flash('Note is too short',category='error')
         else:
-            new_note = Note(data=note,user_id=current_user.id)
+            new_note = Note(data=note,user_id=current_user.id, category_id=category.id if category else None)
             db.session.add(new_note)
             db.session.commit()
             flash('Note added',category='success')
 
-    return render_template("home.html",user=current_user)
+    categories = Category.query.filter_by(user_id=current_user.id).all()
+    notes = current_user.notes
+    return render_template("home.html",user=current_user, categories=categories, notes=notes)
+
+
+@views.route('/category/<int:category_id>')
+@login_required
+def notes_by_category(category_id):
+    category = Category.query.filter_by(id=category_id, user_id=current_user.id).first_or_404()
+    categories = Category.query.filter_by(user_id=current_user.id).all()
+    notes = Note.query.filter_by(user_id=current_user.id, category_id=category_id).all()
+    return render_template("home.html", user=current_user, categories=categories, notes=notes, selected_category=category)
 
 @views.route('/delete-note', methods=['POST'])
 def delete_note():  


### PR DESCRIPTION
## Summary
- add `Category` model and hook up user ownership
- connect categories to notes
- extend home page to choose/create categories
- allow filtering notes by category

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685595c9a6f483289e2a091380657ea1