### PR TITLE
Add subject categorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Flask Notes Web Application is a feature-rich web platform designed to provi
 2. Note Creation and Organization:
 
 * Users can create, edit, and delete notes.
-* Notes can be organized into categories or tags for easy navigation.
+* Notes can be organized into categories based on subject for easy navigation.
 * Notes can be reordered via drag-and-drop using SortableJS.
 * Rich text editing capabilities enable users to format their notes.
 

--- a/tests/test_subject.py
+++ b/tests/test_subject.py
@@ -1,0 +1,53 @@
+import pytest
+from website import create_app, db
+from website.models import Note
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config.update({
+        "TESTING": True,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        "SECRET_KEY": "test-secret",
+    })
+    with app.app_context():
+        db.create_all()
+        yield app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def signup(client, email="user@example.com", password="password"):
+    return client.post(
+        "/signup",
+        data={
+            "email": email,
+            "firstName": "Test",
+            "password1": password,
+            "password2": password,
+        },
+        follow_redirects=True,
+    )
+
+
+def login(client, email="user@example.com", password="password"):
+    return client.post(
+        "/login",
+        data={"email": email, "password": password},
+        follow_redirects=True,
+    )
+
+
+def test_note_subject_saved(client, app):
+    signup(client)
+    login(client)
+    client.post(
+        "/",
+        data={"note": "test note", "subject": "math", "color": "#ff0000"},
+        follow_redirects=True,
+    )
+    with app.app_context():
+        note = Note.query.first()
+        assert note.subject == "math"

--- a/website/models.py
+++ b/website/models.py
@@ -23,13 +23,14 @@ class Position(Enum):
 class Note(db.Model):
     id = db.Column(db.Integer,primary_key=True)
     data = db.Column(db.String(10000))
+    subject = db.Column(db.String(150), default="General")
     date = db.Column(db.DateTime(timezone=True),default=func.now())
     position = db.Column(db.Integer, default=0)
     color = db.Column(db.String(20), default=Color.YELLOW.value)
     position_class = db.Column(db.String(20), default=Position.LEFT.value)
     user_id = db.Column(db.Integer,db.ForeignKey('user.id'))
 
-    ALLOWED_TAGS = bleach.sanitizer.ALLOWED_TAGS + [
+    ALLOWED_TAGS = list(bleach.sanitizer.ALLOWED_TAGS) + [
         "p",
         "pre",
         "span",

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -4,17 +4,22 @@
 {% block content%}
 <h1 align="center">Notes</h1>
 <ul class="list-group list-group-flush" id="notes">
-  {% for note in notes %}
-  <li class="list-group-item" data-id="{{note.id}}" style="background-color: {{ note.color }};">
-    <div class="note-body">{{ note.html|safe }}</div>
-    <button type="button" class="close" onClick="deleteNote({{note.id}})">
-      <span aria-hidden="true">&times;</span>
-    </button>
-  </li>
+  {% for subject, group in notes|groupby('subject') %}
+  <li class="list-group-item active">{{ subject }}</li>
+    {% for note in group %}
+    <li class="list-group-item" data-id="{{note.id}}" style="background-color: {{ note.color }};">
+      <div class="note-body">{{ note.html|safe }}</div>
+      <button type="button" class="close" onClick="deleteNote({{note.id}})">
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </li>
+    {% endfor %}
   {% endfor %}
 </ul>
 <form method="POST">
     <textarea name="note" id="note" class="form-control"></textarea>
+    <br />
+    <input type="text" name="subject" id="subject" class="form-control" placeholder="Subject" />
     <br />
     <input
       type="color"

--- a/website/views.py
+++ b/website/views.py
@@ -14,18 +14,21 @@ def home():
     if request.method == 'POST':
         note = request.form.get('note')
         color = request.form.get('color', '#ffff00')
+        subject = request.form.get('subject', 'General')
         if len(note)<1:
             flash('Note is too short',category='error')
         else:
             # determine next position for the user's notes
             max_pos = db.session.query(db.func.max(Note.position)).filter_by(user_id=current_user.id).scalar()
             next_pos = (max_pos or 0) + 1
-            new_note = Note(data=note,user_id=current_user.id, position=next_pos, color=color)
+            new_note = Note(data=note, user_id=current_user.id,
+                            position=next_pos, color=color, subject=subject)
             db.session.add(new_note)
             db.session.commit()
             flash('Note added',category='success')
 
-    notes = Note.query.filter_by(user_id=current_user.id).order_by(Note.position).all()
+    notes = (Note.query.filter_by(user_id=current_user.id)
+                     .order_by(Note.subject, Note.position).all())
     return render_template("home.html",user=current_user, notes=notes)
 
 @views.route('/delete-note', methods=['POST'])


### PR DESCRIPTION
## Summary
- add subject field to Note model
- show notes grouped by subject and allow specifying subject on create
- fix allowed HTML tags union
- test subject is stored correctly
- update README about categorization

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b284c31c832889ce394b315581b6